### PR TITLE
Add movie details endpoint (GET /movies/:id)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -35,6 +35,46 @@ paths:
                                     status:
                                         type: string
                                         example: 'Alive'
+    /movies/{id}:
+        get:
+            tags: [General]
+            summary: Get movie details
+            description: Returns detailed information for a single movie by its TMDB ID.
+            parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                      type: integer
+                      example: 961323
+                  description: TMDB movie ID
+            responses:
+                '200':
+                    description: Movie details.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MovieResponse'
+                '404':
+                    description: Movie not found
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    error:
+                                        type: string
+                                        example: Movie not found
+                '500':
+                    description: Server error
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    error:
+                                        type: string
+                                        example: Internal server error
     /movies/search:
         get:
             tags: [General]
@@ -178,27 +218,29 @@ components:
         MovieResponse:
             type: object
             properties:
-                code:
-                    type: integer
-                    example: 200
                 id:
                     type: integer
                     example: 961323
-                lang:
-                    type: string
-                    example: en
                 title:
                     type: string
                     example: Nimona
                 description:
                     type: string
                     example: A knight framed for a tragic crime teams with a scrappy, shape-shifting teen to prove his innocence.
-                release_date:
+                releaseDate:
                     type: string
-                    example: 2023-06-23
+                    example: '2023-06-23'
                 poster:
                     type: string
-                    example: TBD # TODO: Do we host these local? Do we pass a blob of image data from TMDB? Do we pass along an absolute url to TMDB?
-                duration:
+                    example: 'https://image.tmdb.org/t/p/w500/2NQljeavtfl22207D1kxLpa4LS3.jpg'
+                genres:
+                    type: array
+                    items:
+                        type: string
+                    example: ['Animation', 'Family', 'Adventure']
+                runtime:
                     type: integer
                     example: 99
+                rating:
+                    type: number
+                    example: 7.9

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -75,6 +75,16 @@ paths:
                                     error:
                                         type: string
                                         example: Internal server error
+                '502':
+                    description: Bad gateway
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    error:
+                                        type: string
+                                        example: Failed to fetch movie details
     /movies/search:
         get:
             tags: [General]

--- a/src/controllers/movies.ts
+++ b/src/controllers/movies.ts
@@ -142,7 +142,7 @@ export const getMovieDetails = async (request: Request, response: Response) => {
         }
 
         if (!result.ok) {
-            response.status(500).json({ error: 'Failed to fetch movie details' });
+            response.status(502).json({ error: 'Failed to fetch movie details' });
             return;
         }
 

--- a/src/controllers/movies.ts
+++ b/src/controllers/movies.ts
@@ -125,3 +125,41 @@ export const getMovies = async (request: Request, response: Response) => {
         response.status(502).json({ error: 'Network error' });
     }
 };
+
+export const getMovieDetails = async (request: Request, response: Response) => {
+    const { id } = request.params;
+
+    try {
+        const result = await fetch(`${BASE_URL}/movie/${encodeURIComponent(String(id))}`, {
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+            },
+        });
+
+        if (result.status === 404) {
+            response.status(404).json({ error: 'Movie not found' });
+            return;
+        }
+
+        if (!result.ok) {
+            response.status(500).json({ error: 'Failed to fetch movie details' });
+            return;
+        }
+
+        const data = (await result.json()) as Record<string, unknown>;
+        const genres = (data.genres as Array<{ id: number; name: string }>).map((g) => g.name);
+
+        response.json({
+            id: data.id,
+            title: data.title,
+            description: data.overview,
+            releaseDate: data.release_date,
+            poster: `https://image.tmdb.org/t/p/w500${data.poster_path}`,
+            genres,
+            runtime: data.runtime,
+            rating: data.vote_average,
+        });
+    } catch (_error) {
+        response.status(500).json({ error: 'Internal server error' });
+    }
+};

--- a/src/routes/movies/details.ts
+++ b/src/routes/movies/details.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getMovieDetails } from '../../controllers/movies';
+
+const detailsRoutes = Router();
+
+detailsRoutes.get('/:id', getMovieDetails);
+
+export { detailsRoutes };

--- a/src/routes/movies/index.ts
+++ b/src/routes/movies/index.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express';
 import { searchRoutes } from './search';
+import { detailsRoutes } from './details';
 
 const movieRoutes = Router();
 
 movieRoutes.use('/search', searchRoutes);
+movieRoutes.use('/', detailsRoutes);
 
 export { movieRoutes };

--- a/tests/movies.test.ts
+++ b/tests/movies.test.ts
@@ -128,6 +128,43 @@ beforeEach(() => {
 });
 
 describe('Movie Routes', () => {
+    describe('GET /movies/:id', () => {
+        it('returns transformed movie details on success', async () => {
+            mockFetch.mockResolvedValue({
+                ok: true,
+                status: 200,
+                json: async () => mockMovieResponse,
+            });
+
+            const res = await request(app).get('/movies/961323');
+            expect(res.status).toBe(200);
+            expect(res.body.id).toBe(961323);
+            expect(res.body.title).toBe('Nimona');
+            expect(res.body.description).toBe(
+                'A knight framed for a tragic crime teams with a scrappy, shape-shifting teen to prove his innocence.'
+            );
+            expect(res.body.releaseDate).toBe('2023-06-23');
+            expect(res.body.poster).toBe(
+                'https://image.tmdb.org/t/p/w500/2NQljeavtfl22207D1kxLpa4LS3.jpg'
+            );
+            expect(res.body.genres).toContain('Animation');
+            expect(res.body.genres).toContain('Family');
+            expect(res.body.runtime).toBe(99);
+            expect(res.body.rating).toBe(7.9);
+        });
+
+        it('returns 404 for an invalid movie id', async () => {
+            mockFetch.mockResolvedValue({
+                ok: false,
+                status: 404,
+                json: async () => ({ status_message: 'The resource you requested could not be found.' }),
+            });
+
+            const res = await request(app).get('/movies/999999999');
+            expect(res.status).toBe(404);
+        });
+    });
+
     describe('GET /movies/search?', () => {
         it('returns transformed search data on success', async () => {
             mockFetch.mockResolvedValue({

--- a/tests/movies.test.ts
+++ b/tests/movies.test.ts
@@ -157,7 +157,9 @@ describe('Movie Routes', () => {
             mockFetch.mockResolvedValue({
                 ok: false,
                 status: 404,
-                json: async () => ({ status_message: 'The resource you requested could not be found.' }),
+                json: async () => ({
+                    status_message: 'The resource you requested could not be found.',
+                }),
             });
 
             const res = await request(app).get('/movies/999999999');


### PR DESCRIPTION
Add a new movie details endpoint and supporting files. Implements getMovieDetails in src/controllers/movies.ts which proxies TMDB (using MOVIE_READ_KEY as a Bearer token), transforms TMDB fields to the API schema (id, title, description, releaseDate, poster URL, genres, runtime, rating), and handles 404 and 500 errors. Adds route file src/routes/movies/details.ts and mounts it in src/routes/movies/index.ts. Updates openapi.yaml with /movies/{id} and MovieResponse schema fields, adds tests in tests/movies.test.ts for success and 404 cases.