### PR TITLE
Update search endpoints to have better title searches

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,7 +6,7 @@ info:
         **Deployed URL:** https://tcss460-team-9-api-72a4ffcce368.herokuapp.com
 
         A RESTful API for the TCSS 460 group project.
-    version: 0.1.0
+    version: 0.2.0
 
 servers:
     - url: https://tcss460-team-9-api-72a4ffcce368.herokuapp.com

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -111,27 +111,35 @@ paths:
                       example: en
                       default: en
                   description: ISO-639 language code
-                - name: text
+                - name: title
                   in: query
                   required: false
                   schema:
                       type: string
                       example: Nimona
-                  description: Search for (case-insensitive) words within the title and description. Comma separated list
+                  description: Search for (case-insensitive) words within the title.
+                - name: description
+                  in: query
+                  required: false
+                  explode: false
+                  schema:
+                      type: array
+                      example: [knight, crime]
+                  description: Filter results for (case-insensitive) words within the description. Comma separated list
                 - name: after
                   in: query
                   required: false
                   schema:
                       type: string
                       example: 2022-05-17
-                  description: Earliest release date allowed among search results (inclusive)
+                  description: Filter earliest release date allowed among search results (inclusive)
                 - name: before
                   in: query
                   required: false
                   schema:
                       type: string
                       example: 2026-03-22
-                  description: Latest release date allowed among search results (inclusive)
+                  description: Filter latest release date allowed among search results (inclusive)
                 - name: sort
                   in: query
                   required: false
@@ -139,7 +147,7 @@ paths:
                       type: string
                       default: popularity
                       enum: [title, popularity, date, rating]
-                  description: Field to sort on
+                  description: Field to sort on. If title parameter is included, uses the default value.
                 - name: order
                   in: query
                   required: false
@@ -147,7 +155,7 @@ paths:
                       type: string
                       default: desc
                       enum: [asc, desc]
-                  description: Sorting order
+                  description: Sorting order. If title parameter is included, uses the default value.
             responses:
                 '200':
                     description: One page of returned movies, with 0 - 20 movies per page.
@@ -266,27 +274,35 @@ paths:
                       example: en
                       default: en
                   description: ISO-639 language code
-                - name: text
+                - name: name
                   in: query
                   required: false
                   schema:
                       type: string
-                      example: Breaking,Bad
-                  description: Search for (case-insensitive) words within the title and description. Comma separated list
+                      example: Breaking Bad
+                  description: Search for (case-insensitive) words within the name.
+                - name: description
+                  in: query
+                  required: false
+                  explode: false
+                  schema:
+                      type: array
+                      example: [teacher, chemistry]
+                  description: Filter results for (case-insensitive) words within the description. Comma separated list
                 - name: after
                   in: query
                   required: false
                   schema:
                       type: string
                       example: 2007-01-13
-                  description: Earliest first air date allowed among search results (inclusive)
+                  description: Filter earliest first air date allowed among search results (inclusive)
                 - name: before
                   in: query
                   required: false
                   schema:
                       type: string
                       example: 2010-03-14
-                  description: Latest first air date allowed among search results (inclusive)
+                  description: Filter latest first air date allowed among search results (inclusive)
                 - name: sort
                   in: query
                   required: false
@@ -294,7 +310,7 @@ paths:
                       type: string
                       default: popularity
                       enum: [name, popularity, date, rating]
-                  description: Field to sort on
+                  description: Field to sort on. If name parameter is included, uses the default value.
                 - name: order
                   in: query
                   required: false
@@ -302,7 +318,7 @@ paths:
                       type: string
                       default: desc
                       enum: [asc, desc]
-                  description: Sorting order
+                  description: Sorting order. If name parameter is included, uses the default value.
             responses:
                 '200':
                     description: One page of returned shows, with 0 - 20 shows per page.

--- a/src/controllers/movies.ts
+++ b/src/controllers/movies.ts
@@ -5,7 +5,8 @@ const BASE_IMAGE_URL = 'https://image.tmdb.org/t/p/w500';
 
 export const getMovies = async (request: Request, response: Response) => {
     const page: number = Number(request.query.page) || 0;
-    const text: string = request.query.text as string;
+    const title: string = request.query.title as string;
+    const description: string = request.query.description as string;
     const lang: string = (request.query.lang || 'en') as string;
     const after: string = request.query.after as string;
     const before: string = request.query.before as string;
@@ -20,15 +21,16 @@ export const getMovies = async (request: Request, response: Response) => {
     };
 
     try {
-        const result = await fetch(
-            `${BASE_URL}/discover/movie?page=${encodeURIComponent(Number(page) + 1)}&sort_by=${encodeURIComponent(sortKey[sort] + '.' + order)}${after ? '&primary_release_date.gte=' + encodeURIComponent(after) : ''}${before ? '&primary_release_date.lte=' + encodeURIComponent(before) : ''}${lang ? '&language=' + encodeURIComponent(lang) : ''}`,
-            {
-                // TMDB Requires the key in a custom header
-                headers: {
-                    Authorization: `Bearer ${process.env.MOVIE_READ_KEY}`,
-                },
-            }
-        );
+        const query: string = title
+            ? `${BASE_URL}/search/movie?query=${title}${lang ? '&language=' + encodeURIComponent(lang) : ''}`
+            : `${BASE_URL}/discover/movie?page=${encodeURIComponent(Number(page) + 1)}&sort_by=${encodeURIComponent(sortKey[sort] + '.' + order)}${after ? '&primary_release_date.gte=' + encodeURIComponent(after) : ''}${before ? '&primary_release_date.lte=' + encodeURIComponent(before) : ''}${lang ? '&language=' + encodeURIComponent(lang) : ''}`;
+
+        const result = await fetch(query, {
+            // TMDB Requires the key in a custom header
+            headers: {
+                Authorization: `Bearer ${process.env.MOVIE_READ_KEY}`,
+            },
+        });
 
         const data = (await result.json()) as Record<string, unknown>;
 
@@ -39,7 +41,7 @@ export const getMovies = async (request: Request, response: Response) => {
 
         const movies: Record<string, unknown>[] = data.results as Record<string, unknown>[];
 
-        const keywords: string[] = text?.split(',') || [];
+        const keywords: string[] = description?.split(',') || [];
 
         const out: object = {
             code: 200,
@@ -50,13 +52,16 @@ export const getMovies = async (request: Request, response: Response) => {
                     keywords.length > 0
                         ? keywords.every(
                               (word) =>
-                                  (movie.title as string)
-                                      .toUpperCase()
-                                      .indexOf(word.toUpperCase()) > -1 ||
                                   (movie.overview as string)
                                       .toUpperCase()
                                       .indexOf(word.toUpperCase()) > -1
                           )
+                        : true
+                )
+                .filter((movie) =>
+                    title
+                        ? (!after || new Date(movie.release_date) >= new Date(after)) &&
+                          (!before || new Date(movie.release_date) <= new Date(before))
                         : true
                 )
                 .map((movie) => {
@@ -73,6 +78,7 @@ export const getMovies = async (request: Request, response: Response) => {
 
         response.json(out);
     } catch (_error) {
+        console.log(_error);
         response.status(502).json({ error: 'Network error', details: _error });
     }
 };

--- a/src/controllers/movies.ts
+++ b/src/controllers/movies.ts
@@ -60,8 +60,8 @@ export const getMovies = async (request: Request, response: Response) => {
                 )
                 .filter((movie) =>
                     title
-                        ? (!after || new Date(movie.release_date) >= new Date(after)) &&
-                          (!before || new Date(movie.release_date) <= new Date(before))
+                        ? (!after || new Date(movie.release_date as string) >= new Date(after)) &&
+                          (!before || new Date(movie.release_date as string) <= new Date(before))
                         : true
                 )
                 .map((movie) => {
@@ -78,7 +78,6 @@ export const getMovies = async (request: Request, response: Response) => {
 
         response.json(out);
     } catch (_error) {
-        console.log(_error);
         response.status(502).json({ error: 'Network error', details: _error });
     }
 };

--- a/src/controllers/shows.ts
+++ b/src/controllers/shows.ts
@@ -105,8 +105,8 @@ export const getShows = async (request: Request, response: Response) => {
                 )
                 .filter((show) =>
                     name
-                        ? (!after || new Date(show.first_air_date) >= new Date(after)) &&
-                          (!before || new Date(show.first_air_date) <= new Date(before))
+                        ? (!after || new Date(show.first_air_date as string) >= new Date(after)) &&
+                          (!before || new Date(show.first_air_date as string) <= new Date(before))
                         : true
                 )
                 .map((show) => {
@@ -123,7 +123,6 @@ export const getShows = async (request: Request, response: Response) => {
 
         response.json(out);
     } catch (_error) {
-        console.log(_error);
         response.status(502).json({ error: 'Network error' });
     }
 };

--- a/src/controllers/shows.ts
+++ b/src/controllers/shows.ts
@@ -51,7 +51,8 @@ export const getShowDetails = async (request: Request, response: Response) => {
 
 export const getShows = async (request: Request, response: Response) => {
     const page: number = Number(request.query.page) || 0;
-    const text: string = request.query.text as string;
+    const name: string = request.query.name as string;
+    const description: string = request.query.description as string;
     const lang: string = (request.query.lang || 'en') as string;
     const after: string = request.query.after as string;
     const before: string = request.query.before as string;
@@ -66,15 +67,15 @@ export const getShows = async (request: Request, response: Response) => {
     };
 
     try {
-        const result = await fetch(
-            `${BASE_URL}/discover/tv?page=${encodeURIComponent(Number(page) + 1)}&sort_by=${encodeURIComponent(sortKey[sort] + '.' + order)}${after ? '&first_air_date.gte=' + encodeURIComponent(after) : ''}${before ? '&first_air_date.lte=' + encodeURIComponent(before) : ''}${lang ? '&language=' + encodeURIComponent(lang) : ''}`,
-            {
-                // TMDB Requires the key in a custom header
-                headers: {
-                    Authorization: `Bearer ${process.env.MOVIE_READ_KEY}`,
-                },
-            }
-        );
+        const query: string = name
+            ? `${BASE_URL}/search/tv?query=${name}${lang ? '&language=' + encodeURIComponent(lang) : ''}`
+            : `${BASE_URL}/discover/tv?page=${encodeURIComponent(Number(page) + 1)}&sort_by=${encodeURIComponent(sortKey[sort] + '.' + order)}${after ? '&first_air_date.gte=' + encodeURIComponent(after) : ''}${before ? '&first_air_date.lte=' + encodeURIComponent(before) : ''}${lang ? '&language=' + encodeURIComponent(lang) : ''}`;
+        const result = await fetch(query, {
+            // TMDB Requires the key in a custom header
+            headers: {
+                Authorization: `Bearer ${process.env.MOVIE_READ_KEY}`,
+            },
+        });
 
         const data = (await result.json()) as Record<string, unknown>;
 
@@ -85,7 +86,7 @@ export const getShows = async (request: Request, response: Response) => {
 
         const shows: Record<string, unknown>[] = data.results as Record<string, unknown>[];
 
-        const keywords: string[] = text?.split(',') || [];
+        const keywords: string[] = description?.split(',') || [];
 
         const out: object = {
             code: 200,
@@ -96,12 +97,16 @@ export const getShows = async (request: Request, response: Response) => {
                     keywords.length > 0
                         ? keywords.every(
                               (word) =>
-                                  (show.name as string).toUpperCase().indexOf(word.toUpperCase()) >
-                                      -1 ||
                                   ((show.overview as string) || '')
                                       .toUpperCase()
                                       .indexOf(word.toUpperCase()) > -1
                           )
+                        : true
+                )
+                .filter((show) =>
+                    name
+                        ? (!after || new Date(show.first_air_date) >= new Date(after)) &&
+                          (!before || new Date(show.first_air_date) <= new Date(before))
                         : true
                 )
                 .map((show) => {
@@ -118,6 +123,7 @@ export const getShows = async (request: Request, response: Response) => {
 
         response.json(out);
     } catch (_error) {
+        console.log(_error);
         response.status(502).json({ error: 'Network error' });
     }
 };


### PR DESCRIPTION
Modifies search endpoints:
- Splits `text` param into `title`/`name` and `description`
- Notes that `sort` & `order` params have no effect with `title`/`name` searches

Resolves #26 