### PR TITLE
Swap role validation to check local user

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -5,19 +5,14 @@ import { defineConfig } from 'prisma/config';
 export default defineConfig({
     schema: path.join('prisma', 'schema.prisma'),
     datasource: {
-        url: process.env.DATABASE_URL!,
+        url: process.env.DATABASE!,
     },
     migrate: {
         // Dynamic imports keep pg out of the CLI bundle; same connection as the app runtime.
         async adapter() {
             const { Pool } = await import('pg');
             const { PrismaPg } = await import('@prisma/adapter-pg');
-            const pool = new Pool({
-                connectionString: process.env.DATABASE_URL,
-                ssl: process.env.DATABASE_URL?.includes('localhost')
-                    ? false
-                    : { rejectUnauthorized: false },
-            });
+            const pool = new Pool({ connectionString: process.env.DATABASE });
             return new PrismaPg(pool);
         },
     },

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from '../src/generated/prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import 'dotenv/config';
 
-const connectionString = process.env.DATABASE_URL!;
+const connectionString = process.env.DATABASE!;
 const adapter = new PrismaPg({ connectionString });
 const prisma = new PrismaClient({ adapter });
 

--- a/src/middleware/requireAuth.ts
+++ b/src/middleware/requireAuth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction, RequestHandler, ErrorRequestHandler } from 'express';
 import { expressjwt, type Request as JwtRequest } from 'express-jwt';
 import jwksRsa from 'jwks-rsa';
+import { resolveLocalUser } from '../auth/resolveLocalUser';
 
 export const ROLE_HIERARCHY = ['User', 'Moderator', 'Admin', 'SuperAdmin', 'Owner'] as const;
 export type Role = (typeof ROLE_HIERARCHY)[number];
@@ -65,9 +66,6 @@ const handleAuthError: ErrorRequestHandler = (error, _request, response, next) =
 /**
  * Verifies the Authorization: Bearer <token> header against the auth-squared
  * issuer's JWKS (RS256) and attaches the decoded payload to request.user.
- *
- * Replaces backend-2's HS256 + JWT_SECRET verification. Token issuance is
- * entirely owned by auth-squared; this API never mints tokens.
  */
 export const requireAuth: Array<RequestHandler | ErrorRequestHandler> = [
     verifyJwt,
@@ -76,21 +74,27 @@ export const requireAuth: Array<RequestHandler | ErrorRequestHandler> = [
 ];
 
 /**
- * Exact-match role gate. Use after requireAuth:
- *
- *   router.delete('/messages/:id', requireAuth, requireRole('Admin'), handler);
+ * Exact-match role gate. Use after requireAuth.
  */
 export const requireRole = (role: Role): RequestHandler => {
     return (request: Request, response: Response, next: NextFunction): void => {
-        if (!request.user) {
-            response.status(401).json({ error: 'Not authenticated' });
+        try {
+            if (!request.user) {
+                response.status(401).json({ error: 'Not authenticated' });
+                return;
+            }
+            // Check against local user role so we can control role without going to Auth2
+            const localUser = await resolveLocalUser(request);
+
+            if (localUser.role !== role) {
+                response.status(403).json({ error: 'Insufficient permissions' });
+                return;
+            }
+            next();
+        } catch (_error) {
+            response.status(500).json({ error: 'Internal server error' });
             return;
         }
-        if (request.user.role !== role) {
-            response.status(403).json({ error: 'Insufficient permissions' });
-            return;
-        }
-        next();
     };
 };
 
@@ -98,21 +102,27 @@ export const requireRole = (role: Role): RequestHandler => {
  * Minimum-role gate using the 5-tier auth-squared hierarchy:
  * User < Moderator < Admin < SuperAdmin < Owner
  *
- *   router.delete('/messages/:id', requireAuth, requireRoleAtLeast('Admin'), handler);
  */
 export const requireRoleAtLeast = (minRole: Role): RequestHandler => {
     const minIdx = ROLE_HIERARCHY.indexOf(minRole);
     return (request: Request, response: Response, next: NextFunction): void => {
-        if (!request.user) {
-            response.status(401).json({ error: 'Not authenticated' });
-            return;
+        try {
+            if (!request.user) {
+                response.status(401).json({ error: 'Not authenticated' });
+                return;
+            }
+            // Check against local user role so we can control role without going to Auth2
+            const localUser = await resolveLocalUser(request);
+
+            const userIdx = ROLE_HIERARCHY.indexOf(localUser.role);
+            if (userIdx < 0 || userIdx < minIdx) {
+                response.status(403).json({ error: 'Insufficient permissions' });
+                return;
+            }
+            next();
+        } catch (_error) {
+            response.status(500).json({ error: 'Internal server error' });
         }
-        const userIdx = ROLE_HIERARCHY.indexOf(request.user.role);
-        if (userIdx < 0 || userIdx < minIdx) {
-            response.status(403).json({ error: 'Insufficient permissions' });
-            return;
-        }
-        next();
     };
 };
 

--- a/src/middleware/requireAuth.ts
+++ b/src/middleware/requireAuth.ts
@@ -84,13 +84,17 @@ export const requireRole = (role: Role): RequestHandler => {
                 return;
             }
             // Check against local user role so we can control role without going to Auth2
-            const localUser = await resolveLocalUser(request);
-
-            if (localUser.role !== role) {
-                response.status(403).json({ error: 'Insufficient permissions' });
-                return;
-            }
-            next();
+            const localUser = resolveLocalUser(request);
+            localUser.then(
+                (res) => {
+                    if (res.role !== role) {
+                        response.status(403).json({ error: 'Insufficient permissions' });
+                        return;
+                    }
+                    next();
+                },
+                () => response.status(500).json({ error: 'Internal server error' })
+            );
         } catch (_error) {
             response.status(500).json({ error: 'Internal server error' });
             return;
@@ -112,14 +116,18 @@ export const requireRoleAtLeast = (minRole: Role): RequestHandler => {
                 return;
             }
             // Check against local user role so we can control role without going to Auth2
-            const localUser = await resolveLocalUser(request);
-
-            const userIdx = ROLE_HIERARCHY.indexOf(localUser.role);
-            if (userIdx < 0 || userIdx < minIdx) {
-                response.status(403).json({ error: 'Insufficient permissions' });
-                return;
-            }
-            next();
+            const localUser = resolveLocalUser(request);
+            localUser.then(
+                (res) => {
+                    const userIdx = ROLE_HIERARCHY.indexOf(res.role);
+                    if (userIdx < 0 || userIdx < minIdx) {
+                        response.status(403).json({ error: 'Insufficient permissions' });
+                        return;
+                    }
+                    next();
+                },
+                () => response.status(500).json({ error: 'Internal server error' })
+            );
         } catch (_error) {
             response.status(500).json({ error: 'Internal server error' });
         }

--- a/src/middleware/requireAuth.ts
+++ b/src/middleware/requireAuth.ts
@@ -93,7 +93,10 @@ export const requireRole = (role: Role): RequestHandler => {
                     }
                     next();
                 },
-                () => response.status(500).json({ error: 'Internal server error' })
+                () => {
+                    response.status(500).json({ error: 'Internal server error' });
+                    return;
+                }
             );
         } catch (_error) {
             response.status(500).json({ error: 'Internal server error' });
@@ -126,7 +129,10 @@ export const requireRoleAtLeast = (minRole: Role): RequestHandler => {
                     }
                     next();
                 },
-                () => response.status(500).json({ error: 'Internal server error' })
+                () => {
+                    response.status(500).json({ error: 'Internal server error' });
+                    return;
+                }
             );
         } catch (_error) {
             response.status(500).json({ error: 'Internal server error' });


### PR DESCRIPTION
Swaps our role validation from checking the `user.role` header in the request to retrieving role information from our DB. This allows us to modify user roles for our API without going out to Auth2, and critically, allowing us to test our admin-gated routes in production.